### PR TITLE
Endpoint updates

### DIFF
--- a/server/routes/cleanES.js
+++ b/server/routes/cleanES.js
@@ -18,7 +18,19 @@ const cleanBucketedBarChartSentiment = (results) => {
   return obj;
 };
 
+const cleanGender = (input) => {
+  if (input === 1 || input === 0) {
+    return input;
+  } else if (input === 'male') {
+    return 0;
+  } else if (input === 'female') {
+    return 1;
+  }
+  return false;
+};
+
 module.exports = {
   cleanAdjacencyMatrix,
   cleanBucketedBarChartSentiment,
+  cleanGender,
 };

--- a/server/routes/cleanES.js
+++ b/server/routes/cleanES.js
@@ -6,6 +6,26 @@ const cleanAdjacencyMatrix = (buckets) => {
   return obj;
 };
 
+const cleanBucketedBarChartSentiment = (results) => {
+  const obj = {};
+  results.buckets.forEach((bucket) => {
+    if (!obj[bucket.key]) {
+      obj[bucket.key] = [0, 0];
+    }
+
+    bucket.sentimentScore.buckets.forEach((subBucket) => {
+      if (subBucket.key < 0) {
+        obj[bucket.key][0] += subBucket.doc_count;
+      }
+      if (subBucket.key > 0) {
+        obj[bucket.key][1] += subBucket.doc_count;
+      }
+    });
+  });
+  return obj;
+};
+
 module.exports = {
   cleanAdjacencyMatrix,
+  cleanBucketedBarChartSentiment,
 };

--- a/server/routes/cleanES.js
+++ b/server/routes/cleanES.js
@@ -10,17 +10,10 @@ const cleanBucketedBarChartSentiment = (results) => {
   const obj = {};
   results.buckets.forEach((bucket) => {
     if (!obj[bucket.key]) {
-      obj[bucket.key] = [0, 0];
+      obj[bucket.key] = { positiveSentiment: 0, negativeSentiment: 0 };
     }
-
-    bucket.sentimentScore.buckets.forEach((subBucket) => {
-      if (subBucket.key < 0) {
-        obj[bucket.key][0] += subBucket.doc_count;
-      }
-      if (subBucket.key > 0) {
-        obj[bucket.key][1] += subBucket.doc_count;
-      }
-    });
+    obj[bucket.key].positiveSentiment += bucket.interactions.buckets[1].doc_count;
+    obj[bucket.key].negativeSentiment += bucket.interactions.buckets[0].doc_count;
   });
   return obj;
 };

--- a/server/routes/cleanES.js
+++ b/server/routes/cleanES.js
@@ -1,0 +1,11 @@
+const cleanAdjacencyMatrix = (buckets) => {
+  const obj = {};
+  buckets.forEach((bucket) => {
+    obj[bucket.key] = bucket.doc_count;
+  });
+  return obj;
+};
+
+module.exports = {
+  cleanAdjacencyMatrix,
+};

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -123,3 +123,19 @@ app.post('/api/BucketedBarChart', (req, res) => {
   }).then(body => body.aggregations.followerCount_ranges)
     .then(data => res.send(data));
 });
+
+app.post('/api/BucketedBarChartBodySentiment', (req, res) => {
+  const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
+  let esBody = queries.BucketedBarChartSentimentBody();
+
+  esBody = queries.addKeywordToMusts(esBody, keyword);
+
+  client.search({
+    index,
+    type,
+    size: 0,
+    from: 0,
+    body: esBody,
+  }).then(body => clean.cleanBucketedBarChartSentiment(body.aggregations.followerCount_ranges))
+    .then(data => res.send(data));
+});

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -15,7 +15,7 @@ const type = 'tweet';
 app.post('/api/KeywordAcrossGender', (req, res) => {
   const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
   const recipientsGender = req.body.recipientsGender === undefined ?
-    false : req.body.recipientsGender;
+    false : clean.cleanGender(req.body.recipientsGender);
   const sentiment = req.body.sentiment || false;
   const senderFollowerMin = req.body.senderFollowerMin || false;
   const senderFollowerMax = req.body.senderFollowerMax || false;
@@ -38,9 +38,10 @@ app.post('/api/KeywordAcrossGender', (req, res) => {
 
 app.post('/api/KeywordAcrossFollowerCount', (req, res) => {
   const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
-  const senderGender = req.body.senderGender === undefined ? false : req.body.senderGender;
+  const senderGender = req.body.senderGender === undefined ?
+    false : clean.cleanGender(req.body.senderGender);
   const recipientsGender = req.body.recipientsGender === undefined ?
-    false : req.body.recipientsGender;
+    false : clean.cleanGender(req.body.recipientsGender);
   const sentiment = req.body.sentiment || false;
   let esBody = queries.KeywordAcrossFollowerCountBody();
 
@@ -61,9 +62,10 @@ app.post('/api/KeywordAcrossFollowerCount', (req, res) => {
 
 app.post('/api/KeywordAcrossSentiment', (req, res) => {
   const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
-  const senderGender = req.body.senderGender === undefined ? false : req.body.senderGender;
+  const senderGender = req.body.senderGender === undefined ?
+    false : clean.cleanGender(req.body.senderGender);
   const recipientsGender = req.body.recipientsGender === undefined ?
-    false : req.body.recipientsGender;
+    false : clean.cleanGender(req.body.recipientsGender);
   const senderFollowerMin = req.body.senderFollowerMin || false;
   const senderFollowerMax = req.body.senderFollowerMax || false;
   let esBody = queries.KeywordAcrossSentimentBody();
@@ -85,9 +87,10 @@ app.post('/api/KeywordAcrossSentiment', (req, res) => {
 
 app.post('/api/SelectionsOverTime', (req, res) => {
   const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
-  const senderGender = req.body.senderGender === undefined ? false : req.body.senderGender;
+  const senderGender = req.body.senderGender === undefined ?
+    false : clean.cleanGender(req.body.senderGender);
   const recipientsGender = req.body.recipientsGender === undefined ?
-    false : req.body.recipientsGender;
+    false : clean.cleanGender(req.body.recipientsGender);
   const sentiment = req.body.sentiment || false;
   const senderFollowerMin = req.body.senderFollowerMin || false;
   const senderFollowerMax = req.body.senderFollowerMax || false;
@@ -137,6 +140,5 @@ app.post('/api/BucketedBarChartBodySentiment', (req, res) => {
     from: 0,
     body: esBody,
   }).then(body => clean.cleanBucketedBarChartSentiment(body.aggregations.followerCount_ranges))
-  // }).then(body => body.aggregations.followerCount_ranges)
     .then(data => res.send(data));
 });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -137,5 +137,6 @@ app.post('/api/BucketedBarChartBodySentiment', (req, res) => {
     from: 0,
     body: esBody,
   }).then(body => clean.cleanBucketedBarChartSentiment(body.aggregations.followerCount_ranges))
+  // }).then(body => body.aggregations.followerCount_ranges)
     .then(data => res.send(data));
 });

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -13,7 +13,7 @@ const index = 'twitter';
 const type = 'tweet';
 
 app.post('/api/KeywordAcrossGender', (req, res) => {
-  const keyword = req.body.keyword ? req.body.keyword.replace(' ', '*') : '*';
+  const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
   const recipientsGender = req.body.recipientsGender === undefined ?
     false : req.body.recipientsGender;
   const sentiment = req.body.sentiment || false;
@@ -60,7 +60,7 @@ app.post('/api/KeywordAcrossFollowerCount', (req, res) => {
 });
 
 app.post('/api/KeywordAcrossSentiment', (req, res) => {
-  const keyword = req.body.keyword ? req.body.keyword.replace(' ', '*') : '*';
+  const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
   const senderGender = req.body.senderGender === undefined ? false : req.body.senderGender;
   const recipientsGender = req.body.recipientsGender === undefined ?
     false : req.body.recipientsGender;
@@ -84,7 +84,7 @@ app.post('/api/KeywordAcrossSentiment', (req, res) => {
 });
 
 app.post('/api/SelectionsOverTime', (req, res) => {
-  const keyword = req.body.keyword ? req.body.keyword.replace(' ', '*') : '*';
+  const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
   const senderGender = req.body.senderGender === undefined ? false : req.body.senderGender;
   const recipientsGender = req.body.recipientsGender === undefined ?
     false : req.body.recipientsGender;
@@ -109,7 +109,7 @@ app.post('/api/SelectionsOverTime', (req, res) => {
 });
 
 app.post('/api/BucketedBarChart', (req, res) => {
-  const keyword = req.body.keyword ? req.body.keyword.replace(' ', '*') : '*';
+  const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
   let esBody = queries.BucketedBarChartBody();
 
   esBody = queries.addKeywordToMusts(esBody, keyword);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -2,6 +2,8 @@ require('dotenv').config();
 const app = require('../../server.js');
 const elasticsearch = require('elasticsearch');
 const queries = require('./queries.js');
+const clean = require('./cleanES.js');
+
 
 const client = new elasticsearch.Client({
   host: process.env.ELASTICSEARCH_HOST,
@@ -35,7 +37,7 @@ app.post('/api/KeywordAcrossGender', (req, res) => {
 });
 
 app.post('/api/KeywordAcrossFollowerCount', (req, res) => {
-  const keyword = req.body.keyword ? req.body.keyword.replace(' ', '*') : '*';
+  const keyword = req.body.keyword ? req.body.keyword.toLowerCase().replace(' ', '*') : '*';
   const senderGender = req.body.senderGender === undefined ? false : req.body.senderGender;
   const recipientsGender = req.body.recipientsGender === undefined ?
     false : req.body.recipientsGender;
@@ -53,7 +55,7 @@ app.post('/api/KeywordAcrossFollowerCount', (req, res) => {
     size: 0,
     from: 0,
     body: esBody,
-  }).then(body => body.aggregations.interactions.buckets)
+  }).then(body => clean.cleanAdjacencyMatrix(body.aggregations.interactions.buckets))
     .then(data => res.send(data));
 });
 
@@ -77,7 +79,7 @@ app.post('/api/KeywordAcrossSentiment', (req, res) => {
     size: 0,
     from: 0,
     body: esBody,
-  }).then(body => body.aggregations.interactions.buckets)
+  }).then(body => clean.cleanAdjacencyMatrix(body.aggregations.interactions.buckets))
     .then(data => res.send(data));
 });
 

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -147,6 +147,37 @@ const BucketedBarChartBody = () =>
   },
   });
 
+const BucketedBarChartSentimentBody = () =>
+  ({ query: {
+    bool: {
+      must: [
+      ],
+    },
+  },
+  aggs: {
+    followerCount_ranges: {
+      range: {
+        field: 'sender.followers_count',
+        ranges: [
+          { from: 0, to: 100 },
+          { from: 101, to: 1000 },
+          { from: 1001, to: 10000 },
+          { from: 10001, to: 100000 },
+          { from: 100001, to: 1000000 },
+          { from: 1000001 },
+        ],
+      },
+      aggs: {
+        sentimentScore: { terms: { field: 'sentiment.score', order: { _term: 'asc' } },
+          aggs: {
+            docCountBySentiment: { value_count: { field: '_index' } },
+          },
+        },
+      },
+    },
+  },
+  });
+
 module.exports = {
   applyFilters,
   addKeywordtoAdjacencyMatrix,
@@ -156,4 +187,5 @@ module.exports = {
   SelectionsOverTimeBody,
   addKeywordToMusts,
   BucketedBarChartBody,
+  BucketedBarChartSentimentBody,
 };

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -147,6 +147,37 @@ const BucketedBarChartBody = () =>
   },
   });
 
+// const BucketedBarChartSentimentBody = () =>
+//   ({ query: {
+//     bool: {
+//       must: [
+//       ],
+//     },
+//   },
+//   aggs: {
+//     followerCount_ranges: {
+//       range: {
+//         field: 'sender.followers_count',
+//         ranges: [
+//           { from: 0, to: 100 },
+//           { from: 101, to: 1000 },
+//           { from: 1001, to: 10000 },
+//           { from: 10001, to: 100000 },
+//           { from: 100001, to: 1000000 },
+//           { from: 1000001 },
+//         ],
+//       },
+//       aggs: {
+//         sentimentScore: { terms: { field: 'sentiment.score', order: { _term: 'asc' } },
+//           aggs: {
+//             docCountBySentiment: { value_count: { field: '_index' } },
+//           },
+//         },
+//       },
+//     },
+//   },
+//   });
+
 const BucketedBarChartSentimentBody = () =>
   ({ query: {
     bool: {
@@ -168,9 +199,12 @@ const BucketedBarChartSentimentBody = () =>
         ],
       },
       aggs: {
-        sentimentScore: { terms: { field: 'sentiment.score', order: { _term: 'asc' } },
-          aggs: {
-            docCountBySentiment: { value_count: { field: '_index' } },
+        interactions: {
+          adjacency_matrix: {
+            filters: {
+              positiveSentiment: { range: { 'sentiment.score': { gt: 0 } } },
+              negativeSentiment: { range: { 'sentiment.score': { lt: 0 } } },
+            },
           },
         },
       },

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -91,7 +91,7 @@ const KeywordAcrossSentimentBody = () =>
     interactions: {
       adjacency_matrix: {
         filters: {
-          positiveSentiment: { range: { 'sentiment.score': { gte: 0 } } },
+          positiveSentiment: { range: { 'sentiment.score': { gt: 0 } } },
           negativeSentiment: { range: { 'sentiment.score': { lt: 0 } } },
         },
       },

--- a/server/routes/queries.js
+++ b/server/routes/queries.js
@@ -147,37 +147,6 @@ const BucketedBarChartBody = () =>
   },
   });
 
-// const BucketedBarChartSentimentBody = () =>
-//   ({ query: {
-//     bool: {
-//       must: [
-//       ],
-//     },
-//   },
-//   aggs: {
-//     followerCount_ranges: {
-//       range: {
-//         field: 'sender.followers_count',
-//         ranges: [
-//           { from: 0, to: 100 },
-//           { from: 101, to: 1000 },
-//           { from: 1001, to: 10000 },
-//           { from: 10001, to: 100000 },
-//           { from: 100001, to: 1000000 },
-//           { from: 1000001 },
-//         ],
-//       },
-//       aggs: {
-//         sentimentScore: { terms: { field: 'sentiment.score', order: { _term: 'asc' } },
-//           aggs: {
-//             docCountBySentiment: { value_count: { field: '_index' } },
-//           },
-//         },
-//       },
-//     },
-//   },
-//   });
-
 const BucketedBarChartSentimentBody = () =>
   ({ query: {
     bool: {


### PR DESCRIPTION
New from this PR:

1. Sending gender in the request body as "female", "male", 1 or 0 is allowed
2. Keyword searches are now case insensitive
3. There is a new endpoint (BucketedBarChartBodySentiment) that allows us to build a bucketed bar chart by sentiment instead of gender
4. Endpoint output for KeywordAcrossFollowerCount, KeywordAcrossSentiment, BucketedBarChartBodySentiment has been cleaned up / simplified