### PR TITLE
Fix histogram ordering bug and some prop types errors

### DIFF
--- a/src/chartComponents/histogram.jsx
+++ b/src/chartComponents/histogram.jsx
@@ -5,8 +5,10 @@ const TCEHistogram = (props) => {
   const data = props.data;
   const arrayOfDataForCategoryA = [];
   const arrayOfDataForCategoryB = [];
-
-  const arrayOfFollowerRanges = Object.keys(data);
+  const arrayOfFollowerRanges = Object.keys(data)
+    .sort((a, b) =>
+      a.split('-')[0] - b.split('-')[0],
+    );
   arrayOfFollowerRanges.forEach((key) => {
     arrayOfDataForCategoryA.push(data[key][props.params.dataNameA]);
     arrayOfDataForCategoryB.push(data[key][props.params.dataNameB]);
@@ -14,7 +16,9 @@ const TCEHistogram = (props) => {
 
   const allZeroes = array => array.every(item => item === 0);
   if (allZeroes(arrayOfDataForCategoryA.concat(arrayOfDataForCategoryB))) {
-    return (<div>Sorry, there are no tweets with the keyword {props.keyword} in our database!</div>);
+    return (
+      <div>Sorry, there are no tweets with the keyword {props.keyword} in our database!</div>
+    );
   }
 
   const dataForGraph = {

--- a/src/components/AuthNav.jsx
+++ b/src/components/AuthNav.jsx
@@ -29,7 +29,7 @@ class NavBar extends Component {
 
   render() {
     return (
-      <Navbar brand={<Link id="title" to="/">Tweet Insight</Link>} right id="auth-nav">
+      <Navbar brand={'Tweet Insight'} right id="auth-nav">
         <Row>
           <Modal
             counter={this.props.boards}

--- a/src/components/GuestNav.jsx
+++ b/src/components/GuestNav.jsx
@@ -5,7 +5,7 @@ import '../index.css';
 
 export default () =>
   (
-    <Navbar brand={<Link to="/">Tweet Insight</Link>} right style={{ 'margin-bottom': '20px', 'padding-left': '20px' }}>
+    <Navbar brand={'Tweet Insight'} right style={{ marginBottom: '20px', paddingLeft: '20px' }}>
       <Row>
         <NavItem><Link to="/login"><Icon right>account_circle</Icon>Login</Link></NavItem>
       </Row>


### PR DESCRIPTION
Histograms were generated by iterating through an object's keys and inferring meaning from their ordering, which is, of course, not guaranteed. I.e. We get buckets representing 0-100, 101-1000 etc. but we map these to buckets on the Histogram not by value but by the order in which those keys are enumerated (0-100 goes in the first bucket not because it represents the lowest value but because it's key happens to be enumerated first).

The keys are generally enumerated in the order in which they appear in the JSON form which they're parsed. In the case of Elasticsearch this is by value, but from Firebase they're sorted lexicographically. Consequently 1001-10000 comes before 101-1000 because '1' is smaller than '-'. When these keys are enumerated, therefore, we start at 0-100, then jump straight to a million and work backwards.

This fix (which is temporary--again, the long term solution for this **definitely** should be indexing into an object by key not inferring from the value by order in an array) simply orders the array returned from Object.keys by sorting them by low end of the range.